### PR TITLE
[SCRUM-155] 문자 메세지 인증 api 세부 기능 수정 + RedisUtil 기능 추가

### DIFF
--- a/src/main/java/com/swifty/bank/server/api/controller/PhoneAuthenticationController.java
+++ b/src/main/java/com/swifty/bank/server/api/controller/PhoneAuthenticationController.java
@@ -28,8 +28,8 @@ public class PhoneAuthenticationController {
     @Autowired
     private final PhoneAuthenticationServiceImpl phoneAuthenticationService;
 
-    @Operation(summary = "request to send a message to putted in phone number")
-    @PostMapping(value = "/sendMessage")
+    @Operation(summary = "request to send a message")
+    @PostMapping(value = "/send-message")
     public ResponseEntity<?> sendMessage(
             @RequestBody @Valid SendMessageRequest sendMessageRequest
     ) {
@@ -43,7 +43,7 @@ public class PhoneAuthenticationController {
 
     @PassAuth
     @Operation(summary = "request to send a verification code message to putted in phone number")
-    @PostMapping(value = "/sendVerificationCode")
+    @PostMapping(value = "/send-verification-code")
     public ResponseEntity<?> sendVerificationCode(
             @RequestBody @Valid SendVerificationCodeRequest sendVerificationCodeRequest) {
         log.info("sendVerificationCodeRequest() Started: " + sendVerificationCodeRequest.toString());
@@ -57,7 +57,7 @@ public class PhoneAuthenticationController {
 
     @PassAuth
     @Operation(summary = "method to check if verification code is equal to sent one")
-    @PostMapping(value = "/checkVerificationCode")
+    @PostMapping(value = "/check-verification-code")
     public ResponseEntity<?> checkVerificationCode(
             @RequestBody @Valid CheckVerificationCodeRequest checkVerificationCodeRequest) {
         log.info("checkVerificationCode() Started: " + checkVerificationCodeRequest.toString());

--- a/src/main/java/com/swifty/bank/server/api/service/impl/AuthenticationApiServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/api/service/impl/AuthenticationApiServiceImpl.java
@@ -42,11 +42,10 @@ public class AuthenticationApiServiceImpl implements AuthenticationApiService {
         }
 
         String phoneVerified = redisUtil.getRedisStringValue(
-                HashUtil.createStringHash(
-                        List.of(dto.getDeviceId(),
-                                dto.getPhoneNumber()))
+                HashUtil.createStringHash(List.of("otp-", dto.getPhoneNumber()))
         );
         if (phoneVerified == null || !phoneVerified.equals("true")) {
+            // 만료 되어서 사라졌거나 인증이 된 상태가 아닌 경우
             return new ResponseResult<>(
                     Result.FAIL,
                     "[ERROR] not verified phone number",
@@ -55,7 +54,9 @@ public class AuthenticationApiServiceImpl implements AuthenticationApiService {
         }
 
         Customer customer = customerService.join(dto);
-
+        // 회원가입 절차가 완료된 경우, 전화번호 인증 여부 redis에서 삭제
+        redisUtil.deleteRedisStringValue(HashUtil.createStringHash(List.of("otp-", dto.getPhoneNumber())));
+        
         Customer customerByDeviceId = customerService.findByDeviceId(dto.getDeviceId());
         if (customerByDeviceId != null) {
             customerService.updateDeviceId(

--- a/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/CheckVerificationCodeRequest.java
+++ b/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/CheckVerificationCodeRequest.java
@@ -1,7 +1,7 @@
 package com.swifty.bank.server.core.domain.sms.service.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -10,14 +10,9 @@ import lombok.Data;
 @Schema(description = "Form to get verification code")
 public class CheckVerificationCodeRequest {
     @NotNull
-    @NotBlank
-    @Schema(description = "phone's device id to distinguish users")
-    private String deviceId;
-
-    @NotNull
     @Size(max = 14, min = 3)
-    @Schema(description = "start with +82 and only digits 0-9 without dash", example = "+8201012345678",
-            required = true)
+    @Schema(description = "start with +1 and only digits 0-9 without dash", example = "+12051234567",
+            requiredMode = RequiredMode.REQUIRED)
     private String phoneNumber;
     @Schema(description = "verification which phone's owner got from server")
     private String verificationCode;

--- a/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/SendMessageRequest.java
+++ b/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/SendMessageRequest.java
@@ -2,6 +2,7 @@ package com.swifty.bank.server.core.domain.sms.service.dto;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -11,8 +12,8 @@ import lombok.Data;
 public class SendMessageRequest {
     @NotNull
     @Size(max = 14, min = 3)
-    @Schema(description = "start with +82 and only digits 0-9 without dash", example = "+8201012345678",
-            required = true)
+    @Schema(description = "start with +1 and only digits 0-9 without dash", example = "+12051234567",
+            requiredMode = RequiredMode.REQUIRED)
     private String destinationPhoneNumber;
     @Schema(description = "message to be sent to a phone")
     private String smsMessage;

--- a/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/SendVerificationCodeRequest.java
+++ b/src/main/java/com/swifty/bank/server/core/domain/sms/service/dto/SendVerificationCodeRequest.java
@@ -1,7 +1,7 @@
 package com.swifty.bank.server.core.domain.sms.service.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -10,12 +10,8 @@ import lombok.Data;
 @Schema(description = "Request for to send verification code")
 public class SendVerificationCodeRequest {
     @NotNull
-    @NotBlank
-    @Schema(description = "device Id from replied device")
-    private String deviceId;
-    @NotNull
     @Size(max = 14, min = 3)
-    @Schema(description = "start with +82 and only digits 0-9 without dash", example = "+8201012345678",
-            required = true)
+    @Schema(description = "start with +1 and only digits 0-9 without dash", example = "+12051234567",
+            requiredMode = RequiredMode.REQUIRED)
     private String phoneNumber;
 }

--- a/src/main/java/com/swifty/bank/server/utils/RedisUtil.java
+++ b/src/main/java/com/swifty/bank/server/utils/RedisUtil.java
@@ -1,6 +1,7 @@
 package com.swifty.bank.server.utils;
 
 import com.swifty.bank.server.core.common.authentication.Auth;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,5 +32,13 @@ public class RedisUtil {
 
     public void setRedisStringValue(String key, String value) {
         redisStringTemplate.opsForValue().set(key, value);
+    }
+
+    public Boolean setRedisStringExpiration(String key, int timeout, TimeUnit timeUnit) {
+        return redisStringTemplate.expire(key, timeout, timeUnit);
+    }
+
+    public void deleteRedisStringValue(String key) {
+        redisStringTemplate.opsForHash().delete(key);
     }
 }

--- a/src/test/java/com/swifty/bank/BankApplicationTests.java
+++ b/src/test/java/com/swifty/bank/BankApplicationTests.java
@@ -3,7 +3,7 @@ package com.swifty.bank;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = BankApplicationTests.class)
 class BankApplicationTests {
 
     @Test


### PR DESCRIPTION
# What is this PR?
문자 메세지 인증 api 세부 기능 수정
RedisUtil 기능 추가
test 코드 오류 수정

# What has changed?
- /sms 하위 endpoint url 양식 수정
  - `sendVerificationCode` -> `send-verification-code`
  - 이하 다른 api도 동일한 양식으로 수정
 
- `sendVerificationCodeRequest`, `checkVerificationCodeRequest` 에서 필수 항목 수정
  - deviceId 제거

- RedisUtil 기능 추가
  - delete 기능 추가
  - expiration 부여 기능 추가

- 문자 메세지 인증 완료 후, 인증 만료 기간을 무제한 -> 10분으로 수정

- test 코드 오류 수정
# A notice to reviewers...
LGTM 부탁드립니다