### PR TITLE
JwtUtil 리팩토링 및 기능 수정

### DIFF
--- a/src/main/java/com/swifty/bank/server/api/controller/CustomerController.java
+++ b/src/main/java/com/swifty/bank/server/api/controller/CustomerController.java
@@ -2,8 +2,9 @@ package com.swifty.bank.server.api.controller;
 
 import com.swifty.bank.server.api.controller.dto.customer.request.CustomerInfoUpdateConditionRequest;
 import com.swifty.bank.server.api.controller.dto.customer.request.PasswordRequest;
-import com.swifty.bank.server.api.service.CustomerAPIService;
 import com.swifty.bank.server.api.service.dto.ResponseResult;
+import com.swifty.bank.server.api.service.impl.CustomerApiServiceImpl;
+import com.swifty.bank.server.core.common.authentication.service.impl.AuthenticationServiceImpl;
 import com.swifty.bank.server.core.common.utils.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,15 +25,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Tag(name = "Customer Information API")
 @Slf4j
 public class CustomerController {
-    private final CustomerAPIService customerAPIService;
-    private final JwtUtil jwtUtil;
+    private final CustomerApiServiceImpl customerApiService;
+    private final AuthenticationServiceImpl authenticationService;
 
     @GetMapping("")
     @Operation(summary = "get customer's whole information in database", description = "no request body needed")
     public ResponseEntity<?> customerInfo() {
-        UUID customerId = jwtUtil.getCustomerId();
+        String jwt = JwtUtil.extractJwtFromCurrentRequestHeader();
+        UUID customerId = UUID.fromString(JwtUtil.getClaimByKey(jwt, "customerId").toString());
 
-        ResponseResult<?> customerInfo = customerAPIService.getCustomerInfo(customerId);
+        ResponseResult<?> customerInfo = customerApiService.getCustomerInfo(customerId);
 
         return ResponseEntity
                 .ok()
@@ -43,9 +45,10 @@ public class CustomerController {
     @Operation(summary = "change customer's whole information in database", description = "specific DTO required")
     public ResponseEntity<?> customerInfoUpdate(
             @RequestBody CustomerInfoUpdateConditionRequest customerInfoUpdateCondition) {
-        UUID customerId = jwtUtil.getCustomerId();
+        String jwt = JwtUtil.extractJwtFromCurrentRequestHeader();
+        UUID customerId = UUID.fromString(JwtUtil.getClaimByKey(jwt, "customerId").toString());
 
-        ResponseResult<?> responseResult = customerAPIService.customerInfoUpdate(customerId,
+        ResponseResult<?> responseResult = customerApiService.customerInfoUpdate(customerId,
                 customerInfoUpdateCondition);
 
         return ResponseEntity
@@ -56,9 +59,10 @@ public class CustomerController {
     @PostMapping("/password")
     @Operation(summary = "confirm whether input and original password matches", description = "password string needed")
     public ResponseEntity<?> passwordConfirm(@RequestBody PasswordRequest password) {
-        UUID customerId = jwtUtil.getCustomerId();
+        String jwt = JwtUtil.extractJwtFromCurrentRequestHeader();
+        UUID customerId = UUID.fromString(JwtUtil.getClaimByKey(jwt, "customerId").toString());
 
-        ResponseResult responseResult = customerAPIService.confirmPassword(customerId, password.getPasswd());
+        ResponseResult responseResult = customerApiService.confirmPassword(customerId, password.getPasswd());
 
         return ResponseEntity
                 .ok()
@@ -68,9 +72,10 @@ public class CustomerController {
     @PatchMapping("/password")
     @Operation(summary = "reset password with input", description = "password string needed in body")
     public ResponseEntity<?> passwordReset(@RequestBody PasswordRequest newPassword) {
-        UUID customerId = jwtUtil.getCustomerId();
+        String jwt = JwtUtil.extractJwtFromCurrentRequestHeader();
+        UUID customerId = UUID.fromString(JwtUtil.getClaimByKey(jwt, "customerId").toString());
 
-        ResponseResult responseResult = customerAPIService.resetPassword(customerId, newPassword.getPasswd());
+        ResponseResult responseResult = customerApiService.resetPassword(customerId, newPassword.getPasswd());
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/swifty/bank/server/api/service/CustomerApiService.java
+++ b/src/main/java/com/swifty/bank/server/api/service/CustomerApiService.java
@@ -4,7 +4,7 @@ import com.swifty.bank.server.api.controller.dto.customer.request.CustomerInfoUp
 import com.swifty.bank.server.api.service.dto.ResponseResult;
 import java.util.UUID;
 
-public interface CustomerAPIService {
+public interface CustomerApiService {
     ResponseResult<?> getCustomerInfo(UUID customerUuid);
 
     ResponseResult<?> customerInfoUpdate(UUID customerUuid,

--- a/src/main/java/com/swifty/bank/server/api/service/impl/CustomerApiServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/api/service/impl/CustomerApiServiceImpl.java
@@ -2,7 +2,7 @@ package com.swifty.bank.server.api.service.impl;
 
 import com.swifty.bank.server.api.controller.dto.customer.request.CustomerInfoUpdateConditionRequest;
 import com.swifty.bank.server.api.controller.dto.customer.response.CustomerInfoResponse;
-import com.swifty.bank.server.api.service.CustomerAPIService;
+import com.swifty.bank.server.api.service.CustomerApiService;
 import com.swifty.bank.server.api.service.dto.ResponseResult;
 import com.swifty.bank.server.api.service.dto.Result;
 import com.swifty.bank.server.core.domain.customer.Customer;
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class CustomerApiServiceImpl implements CustomerAPIService {
+public class CustomerApiServiceImpl implements CustomerApiService {
     private final CustomerService customerService;
     private final BCryptPasswordEncoder encoder;
 

--- a/src/main/java/com/swifty/bank/server/core/common/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/swifty/bank/server/core/common/authentication/service/AuthenticationService.java
@@ -16,4 +16,8 @@ public interface AuthenticationService {
     Optional<Auth> findAuthByUuid(UUID uuid);
 
     void saveRefreshTokenInDataSources(String token);
+
+    String createAccessToken(Customer customer);
+
+    String createRefreshToken(Customer customer);
 }

--- a/src/main/java/com/swifty/bank/server/core/common/utils/JwtUtil.java
+++ b/src/main/java/com/swifty/bank/server/core/common/utils/JwtUtil.java
@@ -34,8 +34,13 @@ public class JwtUtil {
 
     public static String extractJwtFromCurrentRequestHeader() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-
-        return request.getHeader("Authorization").split("Bearer ")[1];
+        try {
+            String token = request.getHeader("Authorization").split("Bearer ")[1];
+            validateToken(token);
+            return token;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("올바른 jwt가 존재하지 않습니다.");
+        }
     }
 
     public static Object getClaimByKey(String token, String key) {
@@ -74,15 +79,14 @@ public class JwtUtil {
      * 2. JWS signature was discovered
      * 3. expired token
      */
-    public static boolean validateToken(String token) {
+    public static void validateToken(String token) {
         JwtParser jwtParser = Jwts.parserBuilder()
                 .setSigningKey(getSecretKey())
                 .build();
         try {
             jwtParser.parse(token);
-            return true;
         } catch (Exception e) {
-            return false;
+            throw new IllegalArgumentException("올바른 jwt가 아닙니다.");
         }
     }
 

--- a/src/main/java/com/swifty/bank/server/core/common/utils/JwtUtil.java
+++ b/src/main/java/com/swifty/bank/server/core/common/utils/JwtUtil.java
@@ -1,17 +1,15 @@
 package com.swifty.bank.server.core.common.utils;
 
+import com.swifty.bank.server.exception.TokenContentNotValidException;
+import com.swifty.bank.server.exception.TokenExpiredException;
+import com.swifty.bank.server.exception.TokenNotExistException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
-import java.time.Duration;
 import java.util.Date;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,83 +20,74 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Slf4j
 public class JwtUtil {
     @Value("${jwt.secret}")
-    private String secretKey;
-    private final long accessTokenValidTime = Duration.ofMinutes(30).toMillis(); // 만료시간 30분
-    private final long refreshTokenValidTime = Duration.ofDays(14).toMillis(); // 만료시간 2주
+    private static String secretKey;
 
-    public String createJwtAccessToken(UUID customerUUID) {
-        Key secretKey = getSecretKey();
-
+    public static String generateToken(Claims claims, Date expiration) {
         return Jwts.builder()
                 .setHeaderParam("type", "jwt")
-                .setSubject("AccessToken")
-                .claim("customerId", customerUUID)
+                .setClaims(claims)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidTime))
-                .signWith(secretKey)
+                .setExpiration(expiration)
+                .signWith(getSecretKey())
                 .compact();
     }
 
-    public String createJwtRefreshToken(UUID customerUUID) {
-        Key secretKey = getSecretKey();
-
-        return Jwts.builder()
-                .setHeaderParam("type", "jwt")
-                .setSubject("RefreshToken")
-                .claim("customerId", customerUUID)
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidTime))
-                .signWith(secretKey)
-                .compact();
-    }
-
-    public String getAccessToken() {
+    public static String extractJwtFromCurrentRequestHeader() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
         return request.getHeader("Authorization").split("Bearer ")[1];
     }
 
-    public UUID getCustomerId() {
-        Key secretKey = getSecretKey();
-        String accessToken = getAccessToken();
-
-        if (!isValidateToken(accessToken)) {
-            throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
+    public static Object getClaimByKey(String token, String key) {
+        if (token == null || token.isEmpty()) {
+            throw new TokenNotExistException("[ERROR] there is no token");
+        }
+        // parsing
+        if (token.startsWith("Bearer ")) {
+            // IndexOutOfBound error expected
+            token = token.split(" ")[1].trim();
+        }
+        // check if expired
+        if (isExpiredToken(token)) {
+            throw new TokenExpiredException("[ERROR] Token is expired, reissue it");
         }
 
-        Jws<Claims> claimsJws = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
+        Claims claims = getAllClaims(token);
+        // validate key
+        if (!claims.containsKey(key)) {
+            throw new TokenContentNotValidException("[ERROR] There is no '" + key + "' in token");
+        }
+        return claims.get(key);
+    }
+
+    private static Claims getAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
                 .build()
-                .parseClaimsJws(accessToken);
-
-        return UUID.fromString(claimsJws.getBody().get("customerId", String.class));
+                .parseClaimsJws(token)
+                .getBody();
     }
 
-
-    public boolean isValidateToken(String token) {
+    /*
+     * validate
+     * 1. JWT was incorrectly constructed
+     * 2. JWS signature was discovered
+     * 3. expired token
+     */
+    public static boolean validateToken(String token) {
+        JwtParser jwtParser = Jwts.parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build();
         try {
-            Key secretKey = getSecretKey();
-            Jws<Claims> claimsJws = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
-            String customerId = claimsJws.getBody().get("customerId", String.class);
-
-            if (customerId.isEmpty()) {
-                throw new IllegalArgumentException();
-            }
-
+            jwtParser.parse(token);
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
-        } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
+        } catch (Exception e) {
+            return false;
         }
-        return false;
     }
 
-    public boolean isExpiredToken(String accessToken) {
+
+    public static boolean isExpiredToken(String accessToken) {
         Key secretKey = getSecretKey();
 
         return Jwts.parserBuilder()
@@ -110,7 +99,7 @@ public class JwtUtil {
                 .before(new Date());
     }
 
-    private Key getSecretKey() {
+    private static Key getSecretKey() {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 }

--- a/src/main/java/com/swifty/bank/server/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/swifty/bank/server/interceptor/JwtInterceptor.java
@@ -23,7 +23,6 @@ import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtInterceptor implements HandlerInterceptor {
-    private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
 
     @Override
@@ -33,17 +32,17 @@ public class JwtInterceptor implements HandlerInterceptor {
                 return true;
             }
 
-            String jwtAccessToken = jwtUtil.getAccessToken();
+            String accessToken = req.getHeader("Authorization").split("Bearer ")[1];
 
-            if (!jwtUtil.isValidateToken(jwtAccessToken)) {
-                throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
-            }
-
-            if (jwtUtil.isExpiredToken(jwtAccessToken)) {
+            if (JwtUtil.isExpiredToken(accessToken)) {
                 throw new IllegalArgumentException("만료된 JWT 토큰입니다.");
             }
 
-            if (isLoggedOut(jwtUtil.getCustomerId().toString())) {
+            if (!JwtUtil.validateToken(accessToken)) {
+                throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
+            }
+
+            if (isLoggedOut(JwtUtil.getClaimByKey(accessToken, "customerId").toString())) {
                 throw new IllegalArgumentException("로그아웃 상태의 토큰입니다.");
             }
 

--- a/src/main/java/com/swifty/bank/server/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/swifty/bank/server/interceptor/JwtInterceptor.java
@@ -32,20 +32,11 @@ public class JwtInterceptor implements HandlerInterceptor {
                 return true;
             }
 
-            String accessToken = req.getHeader("Authorization").split("Bearer ")[1];
-
-            if (JwtUtil.isExpiredToken(accessToken)) {
-                throw new IllegalArgumentException("만료된 JWT 토큰입니다.");
-            }
-
-            if (!JwtUtil.validateToken(accessToken)) {
-                throw new IllegalArgumentException("JWT 토큰이 잘못되었습니다.");
-            }
-
+            String accessToken = JwtUtil.extractJwtFromCurrentRequestHeader();
+            JwtUtil.validateToken(accessToken);
             if (isLoggedOut(JwtUtil.getClaimByKey(accessToken, "customerId").toString())) {
                 throw new IllegalArgumentException("로그아웃 상태의 토큰입니다.");
             }
-
             return true;
         } catch (Exception e) {
             ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
# What is this PR?
JwtUtil를 유틸 기능으로 사용할 수 있도록 의존성 제거

# What has changed?
- Customer 엔티티에 대한 의존성을 모두 제거했습니다.
- 커스텀 claim을 설정하는 코드는 JwtUtil이 아닌 담당 service 구현체로 이전시켰습니다.

- 리팩토링 이후 JwtUtil의 주요 기능은 다음과 같습니다.
  - `generateToken(Claims claims, Date expiration)` : 커스텀으로 설정한 claim과 만료기간을 파라미터로 받아 jwt를 생성하여 반환합니다.
  - `extractJwtFromCurrentRequestHeader()` : 현재 요청한 request의 header의 jwt를 반환합니다.
  - `getClaimByKey(String token, String key)`: jwt와 claim의 key값을 파라미터로 받아 해당 key값의 value를 찾아 반환합니다.
  - `validateToken(String token)`: jwt를 검증합니다.
    1. jwt가 정상적으로 construct됐는지
    2. jwt 시그니처가 일치하는지
    3. 기간이 만료된 jwt인지

# A notice to reviewers...
- JwtUtil과 AuthenticationServiceImpl를 위주로 봐주시면 됩니다.