### PR TITLE
[SCRUM-171] redis 기능 추가

### DIFF
--- a/src/main/java/com/swifty/bank/server/core/common/redis/repository/OtpRedisRepository.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/repository/OtpRedisRepository.java
@@ -3,6 +3,7 @@ package com.swifty.bank.server.core.common.redis.repository;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,12 +11,17 @@ import org.springframework.stereotype.Repository;
 public class OtpRedisRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
+    @Nullable
     public String getData(String key) {
         return redisTemplate.opsForValue().get(key);
     }
 
     public void setData(String key, String value, Long timeout, TimeUnit timeUnit) {
         redisTemplate.opsForValue().set(key, value, timeout, timeUnit);
+    }
+
+    public void setDataIfAbsent(String key, String value, Long timeout, TimeUnit timeUnit) {
+        redisTemplate.opsForValue().setIfAbsent(key, value, timeout, timeUnit);
     }
 
     public boolean deleteData(String key) {

--- a/src/main/java/com/swifty/bank/server/core/common/redis/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/repository/RefreshTokenRedisRepository.java
@@ -4,6 +4,7 @@ import com.swifty.bank.server.core.common.redis.entity.RefreshTokenCache;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,11 +12,16 @@ import org.springframework.stereotype.Repository;
 public class RefreshTokenRedisRepository {
     private final RedisTemplate<String, RefreshTokenCache> redisTemplate;
 
+    @Nullable
     public RefreshTokenCache getData(String key) {
         return redisTemplate.opsForValue().get(key);
     }
 
     public void setData(String key, RefreshTokenCache value, Long timeout, TimeUnit timeUnit) {
         redisTemplate.opsForValue().set(key, value, timeout, timeUnit);
+    }
+
+    public void setDataIfAbsent(String key, RefreshTokenCache value, Long timeout, TimeUnit timeUnit) {
+        redisTemplate.opsForValue().setIfAbsent(key, value, timeout, timeUnit);
     }
 }

--- a/src/main/java/com/swifty/bank/server/core/common/redis/service/OtpRedisService.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/service/OtpRedisService.java
@@ -9,5 +9,9 @@ public interface OtpRedisService {
 
     void setData(String key, String value, Long timeout, TimeUnit timeUnit);
 
+    void setDataIfAbsent(String key, String value);
+
+    void setDataIfAbsent(String key, String value, Long timeout, TimeUnit timeUnit);
+
     boolean deleteData(String key);
 }

--- a/src/main/java/com/swifty/bank/server/core/common/redis/service/RefreshTokenRedisService.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/service/RefreshTokenRedisService.java
@@ -1,7 +1,6 @@
 package com.swifty.bank.server.core.common.redis.service;
 
 import com.swifty.bank.server.core.common.redis.entity.RefreshTokenCache;
-
 import java.util.concurrent.TimeUnit;
 
 public interface RefreshTokenRedisService {
@@ -10,4 +9,6 @@ public interface RefreshTokenRedisService {
     void setData(String key, RefreshTokenCache value);
 
     void setData(String key, RefreshTokenCache value, Long timeout, TimeUnit timeUnit);
+
+    void setDataIfAbsent(String key, RefreshTokenCache value);
 }

--- a/src/main/java/com/swifty/bank/server/core/common/redis/service/impl/OtpRedisServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/service/impl/OtpRedisServiceImpl.java
@@ -2,15 +2,18 @@ package com.swifty.bank.server.core.common.redis.service.impl;
 
 import com.swifty.bank.server.core.common.redis.repository.OtpRedisRepository;
 import com.swifty.bank.server.core.common.redis.service.OtpRedisService;
-
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class OtpRedisServiceImpl implements OtpRedisService {
     private final OtpRedisRepository otpRedisRepository;
+
+    @Value("${jwt.redis.otp-timeout-minutes}")
+    private Long timeout;
 
     @Override
     public String getData(String key) {
@@ -19,12 +22,22 @@ public class OtpRedisServiceImpl implements OtpRedisService {
 
     @Override
     public void setData(String key, String value) {
-        otpRedisRepository.setData(key, value, 10L, TimeUnit.MINUTES);
+        otpRedisRepository.setData(key, value, timeout, TimeUnit.MINUTES);
     }
 
     @Override
     public void setData(String key, String value, Long timeout, TimeUnit timeUnit) {
         otpRedisRepository.setData(key, value, timeout, timeUnit);
+    }
+
+    @Override
+    public void setDataIfAbsent(String key, String value) {
+        otpRedisRepository.setDataIfAbsent(key, value, timeout, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void setDataIfAbsent(String key, String value, Long timeout, TimeUnit timeUnit) {
+        otpRedisRepository.setDataIfAbsent(key, value, timeout, timeUnit);
     }
 
     @Override

--- a/src/main/java/com/swifty/bank/server/core/common/redis/service/impl/RefreshTokenRedisServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/core/common/redis/service/impl/RefreshTokenRedisServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 public class RefreshTokenRedisServiceImpl implements RefreshTokenRedisService {
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    @Value("${jwt.redis.timeout}")
+    @Value("${jwt.redis.refresh-token-timeout-minutes}")
     private Long timeout;
 
     @Override
@@ -24,6 +24,11 @@ public class RefreshTokenRedisServiceImpl implements RefreshTokenRedisService {
     @Override
     public void setData(String key, RefreshTokenCache value) {
         refreshTokenRedisRepository.setData(key, value, timeout, TimeUnit.HOURS);
+    }
+
+    @Override
+    public void setDataIfAbsent(String key, RefreshTokenCache value) {
+        refreshTokenRedisRepository.setDataIfAbsent(key, value, timeout, TimeUnit.HOURS);
     }
 
     @Override

--- a/src/main/java/com/swifty/bank/server/core/domain/sms/service/impl/VerifyServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/core/domain/sms/service/impl/VerifyServiceImpl.java
@@ -14,6 +14,9 @@ public class VerifyServiceImpl implements VerifyService {
     private final TwilioMessageService messageService;
     private final OtpRedisServiceImpl redisService;
 
+    private final Long verificationTimeout = 5L;
+    private final Long verificationRetentionTimeout = 10L;
+
     @Override
     public Boolean sendVerificationCode(String phoneNumber) {
         String otp = RandomUtil.generateOtp(6);
@@ -30,7 +33,7 @@ public class VerifyServiceImpl implements VerifyService {
         redisService.setData(
                 phoneNumber,
                 otp,
-                5L,
+                verificationTimeout,
                 TimeUnit.MINUTES
         );
         return true;
@@ -54,7 +57,7 @@ public class VerifyServiceImpl implements VerifyService {
         redisService.setData(
                 phoneNumber,
                 "true",
-                10L,
+                verificationRetentionTimeout,
                 TimeUnit.MINUTES
         );
         return true;


### PR DESCRIPTION
# What is this PR?
redis에 데이터를 삽입할 때 키 값이 이미 존재하는 경우 IllegalArgumentException 발생하는 기능을 추가 했습니다.


# What has changed?
* 기존
  - redis db 내의 키 값이 기존에 존재하든 안 하든 덮어쓰는 기능만 존재
* 변경 후
   - redis db에 키 값이 기존에 존재하든 안 하든 덮어쓰는 기능, 키 값이 이미 존재하는 경우 IllegalArgumentException 발생하는 기능 둘 다 존재 (상황에 맞게 골라서 사용)

# A notice to reviewers...
@su-giana refreshToken 관련 기능에서 키 값 중복 검증이 필요한 부분 수정 바랍니다