### PR TITLE
JWT 검증 로직 보완 및 리팩토링

### DIFF
--- a/src/main/java/com/swifty/bank/server/api/controller/dto/auth/request/CheckLoginAvailabilityRequest.java
+++ b/src/main/java/com/swifty/bank/server/api/controller/dto/auth/request/CheckLoginAvailabilityRequest.java
@@ -28,7 +28,7 @@ public class CheckLoginAvailabilityRequest {
     @Schema(description = "통신사",
             example = "KT",
             requiredMode = RequiredMode.REQUIRED)
-    private String MobileCarrier;
+    private String mobileCarrier;
 
     @NotNull
     @Size(min = 3, max = 14)

--- a/src/main/java/com/swifty/bank/server/core/common/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/swifty/bank/server/core/common/authentication/service/impl/AuthenticationServiceImpl.java
@@ -21,12 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthenticationServiceImpl implements AuthenticationService {
     private final AuthRepository authRepository;
 
-    @Value("${jwt.access-token-expiration-millis}")
-    private int accessTokenExpiration;
-    @Value("${jwt.refresh-token-expiration-millis}")
-    private int refreshTokenExpiration;
-    @Value("${jwt.temporary-token-expiration-millis}")
-    private int temporaryTokenExpiration;
+    @Value("${jwt.access-token-expiration-seconds}")
+    private Long accessTokenExpiration;
+    @Value("${jwt.refresh-token-expiration-seconds}")
+    private Long refreshTokenExpiration;
+    @Value("${jwt.temporary-token-expiration-seconds}")
+    private Long temporaryTokenExpiration;
 
     @Override
     public String createAccessToken(UUID customerUuid) {

--- a/src/main/java/com/swifty/bank/server/core/utils/JwtUtil.java
+++ b/src/main/java/com/swifty/bank/server/core/utils/JwtUtil.java
@@ -44,6 +44,12 @@ public class JwtUtil {
         }
     }
 
+    public static String getSubject(String token) {
+        validateToken(token);
+        Claims claims = getAllClaims(token);
+        return claims.getSubject();
+    }
+
     public static Object getClaimByKey(String token, String key) {
         validateToken(token);
 

--- a/src/main/java/com/swifty/bank/server/exception/common/ExceptionHandler.java
+++ b/src/main/java/com/swifty/bank/server/exception/common/ExceptionHandler.java
@@ -11,7 +11,8 @@ public class ExceptionHandler {
     public ResponseEntity<?> handleException(Exception e) {
         ResponseResult res = new ResponseResult(
                 Result.FAIL,
-                "[ERROR] 알 수 없는 예외가 발생했습니다. 백엔드 단에 문의해 주세요",
+                e.getMessage(),
+//                "[ERROR] 알 수 없는 예외가 발생했습니다. 백엔드 단에 문의해 주세요",
                 null
         );
         return ResponseEntity


### PR DESCRIPTION
# What is this PR?
`JwtInterceptor`에서 검증하는 로직이 보완되었습니다.

# What has changed?
- JwtInterceptor 변경사항
  - 변경 전
    - JWT 자체에 대한 검증(JWT 구조 검증, JWT 내의 만료 기간 검증, 시그니처 검증)만 이루어집니다.
  - 변경 후
    - 권한 어노테이션에 맞는 subject를 가졌는지도 검증합니다.
      - ex1) `@CustomerAuth`를 가진 api로 요청하는 jwt의 subject는 "AccessToken"이어야 합니다.
      - ex2) `@TemporaryAuth`를 가진 api로 요청하는 jwt의 subject는 "TemporaryToken"이어야 합니다.

- `application.yaml`에서 temporary token의 만료기간을 변경했습니다. 
  - 3000000초 -> 300초
- `application.yaml`에서 jwt expiration time관련 변수명이 실제 사용에 맞지 않게 사용되지 않고 있어서 수정했습니다.
  - `millis` -> `seconds`

- 디버깅 편의성을 위해 전역 `ExceptionHandler`에서 에러메세지를 그대로 response로 반환하도록 임시로 수정해두었습니다.

# A notice to reviewers...
리뷰할 내용은 없습니다. 인지만 해주세요!